### PR TITLE
Adding Returns Address via Stock Location

### DIFF
--- a/app/controllers/spree/admin/easypost_settings_controller.rb
+++ b/app/controllers/spree/admin/easypost_settings_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class EasypostSettingsController < Spree::Admin::BaseController
+      before_action :load_stock_locations, only: [:edit, :update]
+
       def edit
       end
 
@@ -11,6 +13,10 @@ module Spree
       end
 
       private
+
+      def load_stock_locations
+        @stock_locations = Spree::StockLocation.all
+      end
 
       def update_easypost_settings
         easypost_settings_params.each do |key, value|
@@ -29,6 +35,7 @@ module Spree
             :carrier_accounts_shipping,
             :carrier_accounts_returns,
             :endorsement_type,
+            :returns_stock_location_id,
         )
       end
     end

--- a/app/models/spree/package_decorator.rb
+++ b/app/models/spree/package_decorator.rb
@@ -34,6 +34,10 @@ module Spree
        (US_STATES_REQUIRING_CUSTOMS.any? { |i| i[shipping_address.state.abbr] })
       end
 
+      def stock_location_returns
+        Spree::StockLocation.find_by(id: Spree::Config[:returns_stock_location_id])
+      end
+
       def easypost_customs_info
         return if !customs_required?
  
@@ -68,8 +72,9 @@ module Spree
 
       def easypost_shipment
         ::EasyPost::Shipment.create(
-          to_address: order.ship_address.easypost_address,
-          from_address: stock_location.easypost_address,
+          to_address: order.ship_address.try(:easypost_address),
+          from_address: stock_location.try(:easypost_address),
+          return_address: stock_location_returns.try(:easypost_address),
           parcel: easypost_parcel,
           customs_info: easypost_customs_info,
           reference: ref_number,

--- a/app/views/spree/admin/easypost_settings/edit.html.erb
+++ b/app/views/spree/admin/easypost_settings/edit.html.erb
@@ -51,6 +51,11 @@
           <label><%= t('endorsement_type') %></label><br />
           <%=  text_field_tag 'settings[endorsement_type]', Spree::Config.endorsement_type %>
         </p>
+
+        <p>
+          <label><%= t('returns_center_stock_location') %></label><br />
+          <%=  select_tag 'settings[returns_stock_location_id]', options_from_collection_for_select(@stock_locations, "id", "admin_name", Spree::Config.returns_stock_location_id) %>
+        </p>
       </fieldset>
     </div>
   </div>

--- a/lib/spree_easypost/engine.rb
+++ b/lib/spree_easypost/engine.rb
@@ -20,6 +20,7 @@ module SpreeEasypost
        preference :carrier_accounts_shipping, :string, default: ''
        preference :carrier_accounts_returns, :string, default: ''
        preference :endorsement_type, :string, default: 'RETURN_SERVICE_REQUESTED'
+       preference :returns_stock_location_id, :integer, default: 0
      end
 
      Spree::ShippingMethod::DISPLAY += [:none]


### PR DESCRIPTION
This allows a returns location to be used as the return address.