### PR TITLE
Adding shipment options to its own block

### DIFF
--- a/app/models/spree/package_decorator.rb
+++ b/app/models/spree/package_decorator.rb
@@ -40,11 +40,11 @@ module Spree
 
       def easypost_customs_info
         return if !customs_required?
- 
+
         customs_items = contents.map do |item|
           variant = item.variant
           product = variant.product
-          
+
           ::EasyPost::CustomsItem.create(
             description: product.taxons.map { |taxon| taxon.name }.join(" "),
             quantity: item.quantity,
@@ -70,6 +70,16 @@ module Spree
         Spree::Config[:carrier_accounts_shipping].split(",")
       end
 
+      def shipment_options
+        {
+          print_custom_1: ref_number,
+          print_custom_1_barcode: true,
+          print_custom_2: build_sku_list,
+          print_custom_2_barcode: false,
+          endorsement: Spree::Config[:endorsement_type]
+        }
+      end
+
       def easypost_shipment
         ::EasyPost::Shipment.create(
           to_address: order.ship_address.try(:easypost_address),
@@ -79,13 +89,7 @@ module Spree
           customs_info: easypost_customs_info,
           reference: ref_number,
           carrier_accounts: carrier_accounts,
-          options: {
-            print_custom_1: ref_number, 
-            print_custom_1_barcode: true,
-            print_custom_2: build_sku_list, 
-            print_custom_2_barcode: false,
-            endorsement: Spree::Config[:endorsement_type]
-          },
+          options: shipment_options
         )
       end
     end

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -49,7 +49,7 @@ module Spree
       private
 
       def use_easypost_to_calculate_rate?(package, shipping_method_filter)
-        package.use_easypost? && package.weight != 0 &&
+        package.use_easypost? && package.weight > 0 &&
         (ShippingMethod::DISPLAY_ON_BACK_END == shipping_method_filter ||
         ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END == shipping_method_filter ||
         is_shipping_rate_dynamic_on_front_end?(shipping_method_filter))

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -10,9 +10,9 @@ module Spree
         if use_easypost_to_calculate_rate?(package, shipping_method_filter)
           shipment = package.easypost_shipment
           rates = shipment.rates.sort_by { |r| r.rate.to_i }
-    
+
           shipping_rates = []
-    
+
           if rates.any?
             rates.each do |rate|
               # See if we can find the shipping method otherwise create it
@@ -29,12 +29,12 @@ module Spree
               # Save the rates that we want to show the customer
               shipping_rates << spree_rate if shipping_method.available_to_display(shipping_method_filter)
             end
-    
+
             # Sets cheapest rate to be selected by default
             if shipping_rates.any?
               shipping_rates.min_by(&:cost).selected = true
             end
-    
+
             shipping_rates
           else
             []
@@ -45,21 +45,21 @@ module Spree
           sort_shipping_rates(rates)
         end
       end
-  
+
       private
 
       def use_easypost_to_calculate_rate?(package, shipping_method_filter)
-        package.use_easypost? &&
-        (ShippingMethod::DISPLAY_ON_BACK_END == shipping_method_filter || 
+        package.use_easypost? && package.weight != 0 &&
+        (ShippingMethod::DISPLAY_ON_BACK_END == shipping_method_filter ||
         ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END == shipping_method_filter ||
         is_shipping_rate_dynamic_on_front_end?(shipping_method_filter))
       end
 
       def is_shipping_rate_dynamic_on_front_end?(shipping_method_filter)
-        Spree::Config[:use_easypost_on_frontend] && 
+        Spree::Config[:use_easypost_on_frontend] &&
         (ShippingMethod::DISPLAY_ON_FRONT_END == shipping_method_filter)
       end
-  
+
       # Cartons require shipping methods to be present, This will lookup a
       # Shipping method based on the admin(internal)_name. This is not user facing
       # and should not be changed in the admin.

--- a/spree_easypost.gemspec
+++ b/spree_easypost.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_core', '>= 3.1.0', '< 4.0'
   s.add_dependency 'spree_extension'
-  s.add_dependency 'easypost', '>= 2.7', '< 2.8'
+  s.add_dependency 'easypost', '>= 2.7'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'capybara-screenshot'


### PR DESCRIPTION
This update fixes an issue where if the package weight is zero throws a 400 error. Also moves the shipment options into its own block which makes it easier to override