### PR TITLE
AVS Fix

### DIFF
--- a/app/models/spree/easypost/address_decorator.rb
+++ b/app/models/spree/easypost/address_decorator.rb
@@ -8,15 +8,14 @@ module Spree
         base.validate :state_validate, :postal_code_validate, if: :use_spree_validations?
       end
 
-      def easypost_address
+      def easypost_address(attributes = {})
         attributes = {
-          verify: ["zip4", "delivery"],
           street1: address1,
           street2: address2,
           city: city,
           zip: zipcode,
           phone: phone
-        }
+        }.merge(attributes)
 
         attributes[:company] = company if respond_to?(:company)
         attributes[:name] = full_name if respond_to?(:full_name)
@@ -29,7 +28,7 @@ module Spree
       def easypost_address_validate
         return true if !Spree::Config.validate_address_with_easypost
 
-        ep_address = easypost_address
+        ep_address = easypost_address({verify: ["zip4", "delivery"]})
         verifications = ep_address.verifications
 
         unless success?(verifications.delivery) && success?(verifications.zip4)

--- a/app/models/spree/easypost/address_decorator.rb
+++ b/app/models/spree/easypost/address_decorator.rb
@@ -26,15 +26,15 @@ module Spree
       end
 
       def easypost_address_validate
-        return true if !Spree::Config.validate_address_with_easypost
+        return true unless Spree::Config.validate_address_with_easypost
 
-        ep_address = easypost_address({verify: ["zip4", "delivery"]})
+        ep_address = easypost_address({ verify: ["zip4", "delivery"] })
         verifications = ep_address.verifications
 
-        unless success?(verifications.delivery) && success?(verifications.zip4)
-          return { errors: get_errors(verifications) }
-        else
+        if success?(verifications.delivery) && success?(verifications.zip4)
           return { suggestions: address_suggestions(ep_address) }
+        else
+          return { errors: get_errors(verifications) }
         end
       end
 
@@ -111,7 +111,6 @@ module Spree
           "E.ADDRESS.NOT_FOUND" =>             :address
         }
       end
-
     end
   end
 end


### PR DESCRIPTION
We don't want to call the Easypost AVS every time an address is created or updated but rather only when we need to verify it through checkout. This fix removes the default checking on every create and only does it through the explicit function call.